### PR TITLE
Add support for useLazyAxios callback to accept data payload

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import { UseAxiosBasic, UseAxiosCancel, UseAxiosRetry } from './useAxios';
 import {
   UseLazyAxiosBasic,
   UseLazyAxiosCancel,
+  UseLazyAxiosPostData,
   UseLazyAxiosRetry,
   UseLazyAxiosUnmount,
 } from './useLazyAxios';
@@ -55,6 +56,11 @@ export default () => {
       <div style={{ marginBottom: 50 }}>
         <h2>useLazyAxios with Retry</h2>
         <UseLazyAxiosRetry />
+      </div>
+
+      <div style={{ marginBottom: 50 }}>
+        <h2>useLazyAxios with POST</h2>
+        <UseLazyAxiosPostData />
       </div>
     </>
   );

--- a/example/src/useLazyAxios/Basic.tsx
+++ b/example/src/useLazyAxios/Basic.tsx
@@ -24,7 +24,7 @@ export default () => {
           {data.data.color}
         </div>
       )}
-      <button type="button" disabled={loading} onClick={getData}>
+      <button type="button" disabled={loading} onClick={() => getData()}>
         get data
       </button>
     </>

--- a/example/src/useLazyAxios/Cancel.tsx
+++ b/example/src/useLazyAxios/Cancel.tsx
@@ -15,7 +15,7 @@ export default () => {
       {loading && 'Loading...'}
       {error && error.message}
       {data && !loading && <div>{data.description}</div>}
-      <button type="button" disabled={loading} onClick={getData}>
+      <button type="button" disabled={loading} onClick={() => getData()}>
         get data
       </button>
       <button type="button" disabled={!loading} onClick={cancel}>

--- a/example/src/useLazyAxios/PostData.tsx
+++ b/example/src/useLazyAxios/PostData.tsx
@@ -1,23 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useLazyAxios } from '../../../src';
 
 export default () => {
+  const [name, setName] = useState('');
+
   const [getData, { data, error, loading }] = useLazyAxios({
     url: 'https://reqres.in/api/users',
     method: 'POST',
   });
-
-  const lazyData = {
-    name: 'morpheus',
-    job: 'leader',
-  };
 
   return (
     <>
       {loading && 'Loading...'}
       {error && error.message}
       {data && !loading && <div>POST Successful</div>}
-      <button type="button" disabled={loading} onClick={() => getData(lazyData)}>
+      {!data && !error && !loading && (
+        <label htmlFor="name">
+          Name:
+          <input
+            id="name"
+            value={name}
+            onChange={event => {
+              setName(event.target.value);
+            }}
+          />
+        </label>
+      )}
+      <button type="button" disabled={loading} onClick={() => getData({ name })}>
         get data
       </button>
     </>

--- a/example/src/useLazyAxios/PostData.tsx
+++ b/example/src/useLazyAxios/PostData.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useLazyAxios } from '../../../src';
+
+export default () => {
+  const [getData, { data, error, loading }] = useLazyAxios({
+    url: 'https://reqres.in/api/users',
+    method: 'POST',
+  });
+
+  const lazyData = {
+    name: 'morpheus',
+    job: 'leader',
+  };
+
+  return (
+    <>
+      {loading && 'Loading...'}
+      {error && error.message}
+      {data && !loading && <div>POST Successful</div>}
+      <button type="button" disabled={loading} onClick={() => getData(lazyData)}>
+        get data
+      </button>
+    </>
+  );
+};

--- a/example/src/useLazyAxios/Unmount.tsx
+++ b/example/src/useLazyAxios/Unmount.tsx
@@ -15,7 +15,7 @@ export default () => {
       {loading && 'Loading...'}
       {error && error.message}
       {data && !loading && <div>{data.description}</div>}
-      <button type="button" disabled={loading} onClick={getData}>
+      <button type="button" disabled={loading} onClick={() => getData()}>
         get data
       </button>
     </>

--- a/example/src/useLazyAxios/index.tsx
+++ b/example/src/useLazyAxios/index.tsx
@@ -1,4 +1,5 @@
 export { default as UseLazyAxiosBasic } from './Basic';
 export { default as UseLazyAxiosCancel } from './Cancel';
+export { default as UseLazyAxiosPostData } from './PostData';
 export { default as UseLazyAxiosRetry } from './Retry';
 export { default as UseLazyAxiosUnmount } from './Unmount';

--- a/src/useBaseAxios.ts
+++ b/src/useBaseAxios.ts
@@ -9,7 +9,10 @@ interface RequestFunctions {
 }
 
 export type Props<Data> = RequestState<Data> & RequestFunctions;
-export type BaseAxios<Data> = [() => Promise<void>, Props<Data>];
+export type BaseAxios<Data> = [
+  (lazyData?: AxiosRequestConfig['data']) => Promise<void>,
+  Props<Data>
+];
 
 function useBaseAxios<Data>(url: string): BaseAxios<Data>;
 function useBaseAxios<Data>(config: AxiosRequestConfig): BaseAxios<Data>;
@@ -21,14 +24,17 @@ function useBaseAxios<Data>(param1: string | AxiosRequestConfig, param2: AxiosRe
 
   const invokeAxios =
     typeof param1 === 'string'
-      ? () => axios(param1, { ...param2, cancelToken })
-      : () => axios({ ...param1, cancelToken });
+      ? (lazyData: AxiosRequestConfig['data']) =>
+          axios(param1, { ...param2, data: lazyData || param2.data, cancelToken })
+      : (lazyData: AxiosRequestConfig['data']) => {
+          return axios({ ...param1, data: lazyData || param1.data, cancelToken });
+        };
 
-  const getData = async () => {
+  const getData = async (lazyData: AxiosRequestConfig['data']) => {
     dispatch({ type: 'REQUEST_INIT' });
 
     try {
-      const res = (await invokeAxios()) as AxiosResponse<Data>;
+      const res = (await invokeAxios(lazyData)) as AxiosResponse<Data>;
 
       if (isMounted.current) {
         dispatch({ type: 'REQUEST_SUCCESS', payload: res.data });


### PR DESCRIPTION
`useLazyAxios`'s callback now accepts an optional data payload to implicitly be passed to `axios`'s `data` property