### PR TITLE
Provide axios instance option

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1338,6 +1338,43 @@
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://csdisco.jfrog.io/csdisco/api/npm/npm/babel-loader/-/babel-loader-8.0.6.tgz",

--- a/example/package.json
+++ b/example/package.json
@@ -22,6 +22,7 @@
     "webpack-dev-server": "^3.8.0"
   },
   "dependencies": {
+    "axios": "^0.19.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { UseAxiosBasic, UseAxiosCancel, UseAxiosChange, UseAxiosRetry } from './useAxios';
+import {
+  UseAxiosBasic,
+  UseAxiosCancel,
+  UseAxiosChange,
+  UseAxiosRetry,
+  UseAxiosCustomInstance,
+} from './useAxios';
 import {
   UseLazyAxiosBasic,
   UseLazyAxiosCancel,
@@ -34,6 +40,11 @@ export default () => {
       <div style={{ marginBottom: 50 }}>
         <h2>useAxios with Retry</h2>
         <UseAxiosRetry />
+      </div>
+
+      <div style={{ marginBottom: 50 }}>
+        <h2>useAxios with Custom Instance</h2>
+        <UseAxiosCustomInstance />
       </div>
 
       <div style={{ marginBottom: 50 }}>

--- a/example/src/useAxios/CustomAxiosInstance.tsx
+++ b/example/src/useAxios/CustomAxiosInstance.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import axios from 'axios';
+import { useAxios } from '../../../src';
+
+interface Data {
+  data: {
+    name: string;
+    color: string;
+  };
+}
+
+const axiosInstance = axios.create({
+  baseURL: 'https://reqres.in/api',
+});
+
+export default () => {
+  const { data, error, loading } = useAxios<Data>('custom/1', {
+    axiosInstance,
+  });
+
+  return (
+    <>
+      {loading && 'Loading...'}
+      {error && error.message}
+      {data && !loading && (
+        <div>
+          {data.data.name}
+          {': '}
+          {data.data.color}
+        </div>
+      )}
+    </>
+  );
+};

--- a/example/src/useAxios/index.tsx
+++ b/example/src/useAxios/index.tsx
@@ -2,3 +2,4 @@ export { default as UseAxiosBasic } from './Basic';
 export { default as UseAxiosCancel } from './Cancel';
 export { default as UseAxiosChange } from './Change';
 export { default as UseAxiosRetry } from './Retry';
+export { default as UseAxiosCustomInstance } from './CustomAxiosInstance';

--- a/src/useAxios.ts
+++ b/src/useAxios.ts
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
-import { AxiosRequestConfig } from 'axios';
-import useBaseAxios, { Props } from './useBaseAxios';
+import useBaseAxios, { Props, Config } from './useBaseAxios';
 
 function useAxios<Data>(url: string): Props<Data>;
-function useAxios<Data>(config: AxiosRequestConfig): Props<Data>;
-function useAxios<Data>(url: string, config: AxiosRequestConfig): Props<Data>;
-function useAxios<Data>(param1: string | AxiosRequestConfig, param2: AxiosRequestConfig = {}) {
+function useAxios<Data>(config: Config): Props<Data>;
+function useAxios<Data>(url: string, config: Config): Props<Data>;
+function useAxios<Data>(param1: string | Config, param2: Config = {}) {
   const invokeUseBaseAxios =
     typeof param1 === 'string'
       ? () => useBaseAxios<Data>(param1, param2)

--- a/src/useLazyAxios.ts
+++ b/src/useLazyAxios.ts
@@ -1,10 +1,9 @@
-import { AxiosRequestConfig } from 'axios';
-import useBaseAxios, { BaseAxios } from './useBaseAxios';
+import useBaseAxios, { BaseAxios, Config } from './useBaseAxios';
 
 function useLazyAxios<Data>(url: string): BaseAxios<Data>;
-function useLazyAxios<Data>(config: AxiosRequestConfig): BaseAxios<Data>;
-function useLazyAxios<Data>(url: string, config: AxiosRequestConfig): BaseAxios<Data>;
-function useLazyAxios<Data>(param1: string | AxiosRequestConfig, param2: AxiosRequestConfig = {}) {
+function useLazyAxios<Data>(config: Config): BaseAxios<Data>;
+function useLazyAxios<Data>(url: string, config: Config): BaseAxios<Data>;
+function useLazyAxios<Data>(param1: string | Config, param2: Config = {}) {
   if (typeof param1 === 'string') {
     return useBaseAxios<Data>(param1, param2);
   }


### PR DESCRIPTION
This PR adds an optional `axiosInstance` config option to allow consumers to pass in their own axios instance per request.

```js
const axiosInstance = axios.create({
  baseURL: 'https://reqres.in/api',
});

const { data, error, loading } = useAxios('custom/1', { axiosInstance });
```

There are other possible ways to design this API, but personally I would like to avoid further overloading our hook functions and to keep the `config` option as flat as possible. This felt like the cleanest approach.

Closes #38.