### PR TITLE
Configure build to generate proper artifact with type definitions

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,9 @@
   "description": "Example app for use-axios-client",
   "main": "src/index.js",
   "scripts": {
-    "start": "webpack-dev-server --open --mode development",
-    "build": "webpack --mode production"
+    "start": "npm run prepare-lib && webpack-dev-server --open --mode development",
+    "build": "npm run prepare-lib && webpack --mode production",
+    "prepare-lib": "cd .. && npm run prepare && cd example"
   },
   "author": "JP Angelle, Zak Angelle",
   "license": "MIT",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,6 +13,7 @@ import {
   UseLazyAxiosRetry,
   UseLazyAxiosUnmount,
 } from './useLazyAxios';
+import CompiledUsage from './compiledUsage';
 
 export default () => {
   const [mount, setMount] = useState(true);
@@ -77,6 +78,11 @@ export default () => {
       <div style={{ marginBottom: 50 }}>
         <h2>useLazyAxios with POST</h2>
         <UseLazyAxiosPostData />
+      </div>
+
+      <div style={{ marginBottom: 50 }}>
+        <h2>Compiled Usage</h2>
+        <CompiledUsage />
       </div>
     </>
   );

--- a/example/src/compiledUsage/index.tsx
+++ b/example/src/compiledUsage/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useAxios } from '../../../bin';
+
+interface Data {
+  data: {
+    name: string;
+    color: string;
+  };
+}
+
+export default () => {
+  const { data, error, loading } = useAxios<Data>('https://reqres.in/api/things/1');
+
+  return (
+    <>
+      {loading && 'Loading...'}
+      {error && error}
+      {data && !loading && (
+        <div>
+          {data.data.name}
+          {': '}
+          {data.data.color}
+        </div>
+      )}
+    </>
+  );
+};

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -2,11 +2,12 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
+  devtool: 'source-map',
   module: {
     rules: [
       {
         test: /\.(js|jsx|ts|tsx)$/,
-        exclude: /node_modules/,
+        exclude: /bin|node_modules/,
         use: {
           loader: 'babel-loader',
         },

--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "use-axios-client",
   "version": "1.0.0",
   "description": "Make axios requests in React using hooks.",
+  "sideEffects": false,
   "main": "bin/index.min.js",
+  "types": "bin/index.d.ts",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint src/*.ts example/**/*.tsx webpack.config.js",
-    "prepare": "webpack --config webpack.config.js",
-    "prettier": "./node_modules/.bin/prettier --write **/*.{ts,tsx}",
+    "build": "webpack --config webpack.config.js",
+    "lint": "eslint src/*.ts example/**/*.tsx webpack.config.js",
+    "prettier": "prettier --write **/*.{ts,tsx}",
     "test": "jest --watch",
-    "tsc": "tsc --noEmit"
+    "test:once": "jest",
+    "tsc": "tsc --emitDeclarationOnly",
+    "prepare": "npm run lint && npm run test:once && npm run tsc && npm run build"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,
+    "declarationDir": "bin",
+    "sourceMap": true,
     "baseUrl": "src",
     "typeRoots": ["src/@types", "node_modules/@types"]
   },
-  "include": ["src", "example"],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const config = {
-  devtool: 'inline-source-map',
+module.exports = {
+  devtool: 'source-map',
   entry: `${__dirname}/src/index.ts`,
   externals: {
     react: 'react',
@@ -18,17 +18,12 @@ const config = {
   },
   output: {
     path: `${__dirname}/bin`,
-    filename: 'index.min.js',
-    library: 'use-axios-client',
-    libraryTarget: 'umd',
-    umdNamedDefine: true,
+    filename: 'index.js',
+    libraryTarget: 'commonjs',
     globalObject: "typeof self !== 'undefined' ? self : this",
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     modules: ['node_modules'],
   },
-  target: 'node',
 };
-
-module.exports = config;


### PR DESCRIPTION
This PR updates our build setup to generate a CommonJS module artifact with proper type declaration files. This allows consumers who _are_ using Typescript to get type checking and consumers who _are not_ using Typescript to consume our library without any issues. 

A few other things:

- Added a new example component called `CompiledUsage` which imports the compiled artifact so we can spot check our build while developing.

- Updated the `prepare` script to run lint, tests, and type checking before generating the build.

- Also set up proper sourcemap generation to provide mappings back to the original TypeScript source files.

![t](https://user-images.githubusercontent.com/1393139/65743419-0ee5f080-e0ba-11e9-9464-7443c2c42e00.gif)

Closes #32, #35, and #46.
