### PR TITLE
Memoize get data

### DIFF
--- a/example/src/pages/UseLazyAxiosPage.tsx
+++ b/example/src/pages/UseLazyAxiosPage.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps } from '@reach/router';
 import {
   UseLazyAxiosBasic,
   UseLazyAxiosCancel,
+  UseLazyAxiosEffectDependency,
   UseLazyAxiosPostData,
   UseLazyAxiosRetry,
   UseLazyAxiosUnmount,
@@ -13,6 +14,7 @@ const UseLazyAxiosPage: React.FC<RouteComponentProps> = () => (
   <Flex wrap="wrap">
     <UseLazyAxiosBasic />
     <UseLazyAxiosCancel />
+    <UseLazyAxiosEffectDependency />
     <UseLazyAxiosPostData />
     <UseLazyAxiosRetry />
     <UseLazyAxiosUnmount />

--- a/example/src/useLazyAxios/EffectDependency.tsx
+++ b/example/src/useLazyAxios/EffectDependency.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+import Container from '../Container';
+import Heading from '../Heading';
+import TextBlock from '../TextBlock';
+import Button from '../Button';
+import { useLazyAxios } from '../../../src';
+
+interface Data {
+  description: string;
+}
+
+export default () => {
+  const [getData, { data, error, loading }] = useLazyAxios<Data>({
+    url: 'https://httpstat.us/200?sleep=3000',
+  });
+
+  const [shouldGetData, setShouldGetData] = useState(false);
+
+  useEffect(() => {
+    if (shouldGetData) {
+      getData();
+    }
+  }, [getData, shouldGetData]);
+
+  return (
+    <Container>
+      <Heading>useLazyAxios with getData Effect Dependency</Heading>
+
+      <TextBlock>
+        {loading && 'Loading...'}
+        {error && error.message}
+        {data && !loading && <div>{data.description}</div>}
+      </TextBlock>
+
+      <Button loading={loading} onClick={() => setShouldGetData(true)}>
+        get data
+      </Button>
+    </Container>
+  );
+};

--- a/example/src/useLazyAxios/index.tsx
+++ b/example/src/useLazyAxios/index.tsx
@@ -1,5 +1,6 @@
 export { default as UseLazyAxiosBasic } from './Basic';
 export { default as UseLazyAxiosCancel } from './Cancel';
+export { default as UseLazyAxiosEffectDependency } from './EffectDependency';
 export { default as UseLazyAxiosPostData } from './PostData';
 export { default as UseLazyAxiosRetry } from './Retry';
 export { default as UseLazyAxiosUnmount } from './Unmount';


### PR DESCRIPTION
This PR fixes an issue where passing `getData` as an effect dependency causes it to retrigger infinitely, since `getData` is not memoized.

The fix is to wrap it in `useCallback` and give it the following dependencies:

- `cancelToken`
- `${JSON.stringify(param1)}.${JSON.stringify(param2)}`

This means that the `getData` function will only get redefined if the request is cancelled (since it needs a new cancel token), or if the hook config changes.