### PR TITLE
Add support for declaring data and error with default parameters

### DIFF
--- a/example/src/pages/UseAxiosPage.tsx
+++ b/example/src/pages/UseAxiosPage.tsx
@@ -8,6 +8,7 @@ import {
   UseAxiosRetry,
   UseAxiosCustomInstance,
   UseAxiosRaceCondition,
+  UseAxiosDefaultParameter,
 } from '../useAxios';
 
 const UseAxiosPage: React.FC<RouteComponentProps> = () => (
@@ -18,6 +19,7 @@ const UseAxiosPage: React.FC<RouteComponentProps> = () => (
     <UseAxiosRetry />
     <UseAxiosCustomInstance />
     <UseAxiosRaceCondition />
+    <UseAxiosDefaultParameter />
   </Flex>
 );
 

--- a/example/src/useAxios/DefaultParameter.tsx
+++ b/example/src/useAxios/DefaultParameter.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Container from '../Container';
+import Heading from '../Heading';
+import TextBlock from '../TextBlock';
+import { useAxios } from '../../../src';
+
+interface Data {
+  data: {
+    name: string;
+    color: string;
+  };
+}
+
+export default () => {
+  const { data = { data: { name: 'salmon', color: '#FA8072' } }, error, loading } = useAxios<Data>(
+    'https://reqres.in/api/bad/request'
+  );
+
+  return (
+    <Container>
+      <Heading>useAxios</Heading>
+
+      <TextBlock>
+        {loading && 'Loading...'}
+        {error && !data && error.message}
+        {data && !loading && (
+          <div>
+            {data.data.name}
+            {': '}
+            {data.data.color}
+          </div>
+        )}
+      </TextBlock>
+    </Container>
+  );
+};

--- a/example/src/useAxios/DefaultParameter.tsx
+++ b/example/src/useAxios/DefaultParameter.tsx
@@ -18,7 +18,7 @@ export default () => {
 
   return (
     <Container>
-      <Heading>useAxios</Heading>
+      <Heading>useAxios with Default Parameters</Heading>
 
       <TextBlock>
         {loading && 'Loading...'}

--- a/example/src/useAxios/DefaultParameter.tsx
+++ b/example/src/useAxios/DefaultParameter.tsx
@@ -11,25 +11,35 @@ interface Data {
   };
 }
 
-export default () => {
+function BaseDefaultParameter() {
   const { data = { data: { name: 'salmon', color: '#FA8072' } }, error, loading } = useAxios<Data>(
     'https://reqres.in/api/bad/request'
   );
 
+  if (data && !loading) {
+    return (
+      <div>
+        {data.data.name}
+        {': '}
+        {data.data.color}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <>Loading...</>;
+  }
+
+  return <>{error && error.message}</>;
+}
+
+export default () => {
   return (
     <Container>
       <Heading>useAxios with Default Parameters</Heading>
 
       <TextBlock>
-        {loading && 'Loading...'}
-        {error && !data && error.message}
-        {data && !loading && (
-          <div>
-            {data.data.name}
-            {': '}
-            {data.data.color}
-          </div>
-        )}
+        <BaseDefaultParameter />
       </TextBlock>
     </Container>
   );

--- a/example/src/useAxios/index.tsx
+++ b/example/src/useAxios/index.tsx
@@ -4,3 +4,4 @@ export { default as UseAxiosChange } from './Change';
 export { default as UseAxiosRetry } from './Retry';
 export { default as UseAxiosCustomInstance } from './CustomAxiosInstance';
 export { default as UseAxiosRaceCondition } from './RaceCondition';
+export { default as UseAxiosDefaultParameter } from './DefaultParameter';

--- a/src/useAxios.test.ts
+++ b/src/useAxios.test.ts
@@ -42,7 +42,7 @@ test('should return data state when axios request resolves', async () => {
 
   expect(cancel).toBeInstanceOf(Function);
   expect(data).toBe(responseData);
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
 });
@@ -66,7 +66,7 @@ test('should return data state when axios request resolves using url signature',
 
   expect(cancel).toBeInstanceOf(Function);
   expect(data).toBe(responseData);
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
 });
@@ -90,7 +90,7 @@ test('should return error state when axios request rejects', async () => {
   const { cancel, data, error, loading, refetch } = result.current;
 
   expect(cancel).toBeInstanceOf(Function);
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toBe(responseError);
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
@@ -114,7 +114,7 @@ test('should return error state when axios request rejects using url signature',
   const { cancel, data, error, loading, refetch } = result.current;
 
   expect(cancel).toBeInstanceOf(Function);
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toBe(responseError);
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
@@ -137,7 +137,7 @@ test('should return data state when refetch resolves', async () => {
   await waitForNextUpdate();
 
   expect(result.current.cancel).toBeInstanceOf(Function);
-  expect(result.current.data).toBe(null);
+  expect(result.current.data).toBeUndefined();
   expect(result.current.error).toBe(error);
   expect(result.current.loading).toBe(false);
   expect(result.current.refetch).toBeInstanceOf(Function);
@@ -150,7 +150,7 @@ test('should return data state when refetch resolves', async () => {
 
   expect(result.current.cancel).toBeInstanceOf(Function);
   expect(result.current.data).toBe(data);
-  expect(result.current.error).toBe(null);
+  expect(result.current.error).toBeUndefined();
   expect(result.current.loading).toBe(false);
   expect(result.current.refetch).toBeInstanceOf(Function);
 });
@@ -183,7 +183,7 @@ test('should return updated state when axios config changes', async () => {
 
   expect(result.current.cancel).toBeInstanceOf(Function);
   expect(result.current.data).toBe(data1);
-  expect(result.current.error).toBe(null);
+  expect(result.current.error).toBeUndefined();
   expect(result.current.loading).toBe(false);
   expect(result.current.refetch).toBeInstanceOf(Function);
 
@@ -195,7 +195,7 @@ test('should return updated state when axios config changes', async () => {
 
   expect(result.current.cancel).toBeInstanceOf(Function);
   expect(result.current.data).toBe(data2);
-  expect(result.current.error).toBe(null);
+  expect(result.current.error).toBeUndefined();
   expect(result.current.loading).toBe(false);
   expect(result.current.refetch).toBeInstanceOf(Function);
 });

--- a/src/useAxiosReducer.test.ts
+++ b/src/useAxiosReducer.test.ts
@@ -12,8 +12,8 @@ test('REQUEST_INIT action type returns loading state', () => {
 
   const { data, error, loading } = result.current[0];
 
-  expect(data).toBe(null);
-  expect(error).toBe(null);
+  expect(data).toBeUndefined();
+  expect(error).toBeUndefined();
   expect(loading).toBe(true);
 });
 
@@ -29,7 +29,7 @@ test('REQUEST_SUCCESS action type returns data response', () => {
   const { data, error, loading } = result.current[0];
 
   expect(data).toEqual({});
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
 });
 
@@ -44,7 +44,25 @@ test('REQUEST_FAILED action type returns error response', () => {
 
   const { data, error, loading } = result.current[0];
 
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toEqual(Error());
   expect(loading).toBe(false);
+});
+
+test('sets data and error to default parameter', () => {
+  const defaultData = { name: 'salmon', color: '#FA8072' };
+
+  const { result } = renderHook(() => useAxiosReducer());
+
+  const dispatch = result.current[1];
+
+  act(() => {
+    dispatch({ type: 'REQUEST_INIT' });
+  });
+
+  const { data = defaultData, error = [], loading } = result.current[0];
+
+  expect(data).toEqual(defaultData);
+  expect(error).toEqual([]);
+  expect(loading).toBe(true);
 });

--- a/src/useAxiosReducer.ts
+++ b/src/useAxiosReducer.ts
@@ -1,9 +1,9 @@
 import { useReducer } from 'react';
 
 export interface RequestState<Data> {
-  data: Data | null;
+  data: Data | undefined;
   loading: boolean;
-  error: Error | null;
+  error: Error | undefined;
 }
 
 type Action<Data> =
@@ -12,8 +12,8 @@ type Action<Data> =
   | { type: 'REQUEST_FAILED'; payload: Error };
 
 export const initialState = {
-  data: null,
-  error: null,
+  data: undefined,
+  error: undefined,
   loading: false,
 };
 
@@ -27,14 +27,14 @@ const createReducer = <Data>() => (
     case 'REQUEST_INIT':
       return {
         ...state,
-        error: null,
+        error: undefined,
         loading: true,
       };
     case 'REQUEST_SUCCESS':
       return {
         ...state,
         data: action.payload,
-        error: null,
+        error: undefined,
         loading: false,
       };
     case 'REQUEST_FAILED':

--- a/src/useBaseAxios.test.ts
+++ b/src/useBaseAxios.test.ts
@@ -38,8 +38,8 @@ test('should load while axios request is pending', async () => {
 
   const { data, error, loading } = result.current[1];
 
-  expect(data).toBe(null);
-  expect(error).toBe(null);
+  expect(data).toBeUndefined();
+  expect(error).toBeUndefined();
   expect(loading).toBe(true);
 
   await waitForNextUpdate();
@@ -66,7 +66,7 @@ test('should return data when axios request resolves', async () => {
   const { data, error, loading } = result.current[1];
 
   expect(data).toEqual({});
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
 });
 
@@ -90,7 +90,7 @@ test('should return data when axios request resolves with url signature', async 
   const { data, error, loading } = result.current[1];
 
   expect(data).toEqual({});
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
 });
 
@@ -115,7 +115,7 @@ test('should return error when axios request rejects', async () => {
 
   const { data, error, loading } = result.current[1];
 
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toBe(errorResponse);
   expect(loading).toBe(false);
 });
@@ -150,8 +150,8 @@ test('request is cancelled on unmount', () => {
   const { data, error, loading } = result.current[1];
 
   expect(cancel).toHaveBeenCalled();
-  expect(data).toBe(null);
-  expect(error).toBe(null);
+  expect(data).toBeUndefined();
+  expect(error).toBeUndefined();
   expect(loading).toBe(true);
 });
 

--- a/src/useLazyAxios.test.ts
+++ b/src/useLazyAxios.test.ts
@@ -46,7 +46,7 @@ test('should return data state when axios request resolves', async () => {
 
   expect(cancel).toBeInstanceOf(Function);
   expect(data).toBe(data);
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
 });
@@ -76,7 +76,7 @@ test('should return data state when axios request resolves using url signature',
 
   expect(cancel).toBeInstanceOf(Function);
   expect(data).toBe(responseData);
-  expect(error).toBe(null);
+  expect(error).toBeUndefined();
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
 });
@@ -106,7 +106,7 @@ test('should return error state when axios request rejects', async () => {
   const { cancel, data, error, loading, refetch } = result.current[1];
 
   expect(cancel).toBeInstanceOf(Function);
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toBe(responseError);
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
@@ -135,7 +135,7 @@ test('should return error state when axios request rejects using url signature',
   const { cancel, data, error, loading, refetch } = result.current[1];
 
   expect(cancel).toBeInstanceOf(Function);
-  expect(data).toBe(null);
+  expect(data).toBeUndefined();
   expect(error).toBe(responseError);
   expect(loading).toBe(false);
   expect(refetch).toBeInstanceOf(Function);
@@ -164,7 +164,7 @@ test('should return data state when refetch resolves', async () => {
   await waitForNextUpdate();
 
   expect(result.current[1].cancel).toBeInstanceOf(Function);
-  expect(result.current[1].data).toBe(null);
+  expect(result.current[1].data).toBeUndefined();
   expect(result.current[1].error).toBe(error);
   expect(result.current[1].loading).toBe(false);
   expect(result.current[1].refetch).toBeInstanceOf(Function);
@@ -177,7 +177,7 @@ test('should return data state when refetch resolves', async () => {
 
   expect(result.current[1].cancel).toBeInstanceOf(Function);
   expect(result.current[1].data).toBe(data);
-  expect(result.current[1].error).toBe(null);
+  expect(result.current[1].error).toBeUndefined();
   expect(result.current[1].loading).toBe(false);
   expect(result.current[1].refetch).toBeInstanceOf(Function);
 });


### PR DESCRIPTION
This PR initializes `data` and `error` as `undefined` so that a consumer has the option to initialize the response with default parameters.

Closes #92 